### PR TITLE
Get tab labels without TST's tabs permission

### DIFF
--- a/web-ext-build.yaml
+++ b/web-ext-build.yaml
@@ -27,6 +27,7 @@ stages:
         permissions:
           - storage
           - notifications
+          - tabs
 
   set-update-url: # TODO: remove
     from: web-ext-build/stages:setWebExtUpdateUrl


### PR DESCRIPTION
For better user experience, the permission confirmation should be done at the installation of this addon. With this change TST Search grabs tab labels by themselves and unifies tree information gotten from TST. How about this change?