### PR TITLE
Flatten states before send #5

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -97,7 +97,7 @@ async function onSubmit({
 
 	// clear previous search on empty term
 	if (!term) {
-		TST.removeTabState({ tabs: '*', state: [].concat(Object.values(classes)), }).catch(onError);
+		TST.removeTabState({ tabs: '*', state: [].concat(Object.values(classes)).flat().filter(state => !!state), }).catch(onError);
 		cache = null; delete actives[windowId];
 		return { matches: 0, cleared: true, };
 	}
@@ -179,11 +179,11 @@ async function onSubmit({
 	(await Promise.all([
 		TST.removeTabState({
 			tabs: Array.from(tabs.byId.keys()), // Explicitly pass the IDs, to ensure consistent runtime with the other calls. The IDs have either just been queried, or wrer the ones that the classes were applied to.
-			state: [].concat(Object.values(classes)),
+			state: [].concat(Object.values(classes)).flat().filter(state => !!state),
 		}).catch(error => void onError(error)),
 		...Object.keys(result).map(
 			state => classes[state].length && result[state].size
-			&& TST.addTabState({ tabs: Array.from(result[state], _=>_.id), state: classes[state], })
+			&& TST.addTabState({ tabs: Array.from(result[state], _=>_.id), state: classes[state].flat().filter(state => !!state), })
 		),
 		typeof seek === 'boolean' && active.tabId >= 0 && TST.scroll({ tab: active.tabId, }),
 		active.tabId >= 0 && TST.addTabState({ tabs: [ active.tabId, ], state: classes.active, }),


### PR DESCRIPTION
After investigation I've realized that tst-search sends nested array via `add-tab-state` and `remove-tab-state` APIs. After some my changes described at https://github.com/piroor/treestyletab/issues/2882 such nested values are become acceptable, but I still think that tst-search should send valid format message according to the spec.

This PR is just an example. I think there should be a utility function to sanitize states before sent.