### PR TITLE
Add ability to support other API providers insteard of TST, like Waterfox Sidebar

### DIFF
--- a/src/common/options.esm.js
+++ b/src/common/options.esm.js
@@ -223,6 +223,12 @@ const isBeta = manifest.applications.gecko.id.endsWith('-dev');
 					#subpanel-header { display: none !important; }
 				`, },
 			},
+			apiProviderId: {
+				title: 'API Provider',
+				description: `Specifies the ID of the TST API provider. If you use a forked version of TST which provide API compatible to TST, ${manifest.name} can communicate with the addon instead of TST.`,
+				default: '',
+				input: { type: 'string', prefix: `Provider ID:`, },
+			},
 		},
 	},
 	export: {


### PR DESCRIPTION
As announced at the [blog entry](https://www.waterfox.net/blog/waterfox-x-treestyletab/), now Waterfox provides a built-in vertical tabs feature based on TST. It is a forked version of TST internally and provides API compatible to TST. With this change TST Tab Search can work with Waterfox's built-in vertical tabs feature. I got a [request from TST Tab Search user](https://twitter.com/inaba_hiroto/status/1774772270650769438) so I've tried to make it compatible with Waterfox also. Could you consider to merge this change?

Steps to verify (for now):

1. Download Waterfox G6.0.10 or later from https://www.waterfox.net/download/
2. Install Waterfox.
3. Start Waterfox.
4. Go to `about:config` and set `browser.sidebar.disabled` to `false` (because it is disabled for now as an experimental feature.)
5. Install TST Tab Search to Waterfox.
6. Go to TST Tab Search options.
7. Enter `sidebar@waterfox.net` to the field "Experimental/Advanced Options" => "API Provider" => "Provider ID".
8. Click the "(re-)register with TST" button.