### PR TITLE
Fix scaleY unit causing permanent font shrink in TST

### DIFF
--- a/src/common/options.esm.js
+++ b/src/common/options.esm.js
@@ -114,7 +114,7 @@ const isBeta = manifest.applications.gecko.id.endsWith('-dev');
 							.tab:not(.pinned).tst-search\:not-matching {
 								padding-top: 0; padding-bottom: 1px;
 								margin-bottom: calc(-38px * ${((100-shrink)/100).toFixed(6)});
-								transform: scaleY(${shrink.toFixed(6)}%); transform-origin: top;
+								transform: scaleY(${(shrink/100).toFixed(6)}); transform-origin: top;
 							}
 						` : '', [ { }, { from: 25, to: 80, }, ], ],
 						[ 'opacity', [ false, 60, ], [ { type: 'boolean', }, { prefix: 'Reduce Opacity to', type: 'integer', suffix: '%', }, ], (active, opacity = 60) => active ? String.raw`


### PR DESCRIPTION
## Changes

- Fixed `scaleY` transform value by removing the erroneous `%` unit suffix
- `scaleY(${shrink.toFixed(6)}%)` → `scaleY(${(shrink/100).toFixed(6)})`

## Why

`scaleY()` accepts a unitless `<number>`, not a `<percentage>`. With the `%` suffix, Firefox could interpret `scaleY(50%)` as `scaleY(50)` (50× scale) rather than the intended `scaleY(0.5)`. This caused non-matching tabs to overflow the sidebar massively, triggering TST's compact mode which permanently reduced font sizes on **all** tabs — persisting even after the search was cleared.

## Testing

Tested by extracting the installed XPI, patching the one line, and loading as a temporary add-on via `about:debugging`. Confirmed that performing a search no longer causes permanent font size reduction across all tabs.

Closes #42